### PR TITLE
Cursor Cloud environment notes for cuda-demux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product
+`cuda-demux` is a **CLI binary** (C++17 + CUDA), not a web service. There is no local app server, database, or login flow. End-to-end work means: configure with CMake, build the binary, then run it against an Illumina run folder.
+
+### Build (standard commands)
+See `README.md` and `.github/workflows/build-test.yml`. Preferred configure flags in this environment:
+
+```bash
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=gcc-12 \
+  -DCMAKE_CXX_COMPILER=g++-12 \
+  -DCMAKE_CUDA_HOST_COMPILER=g++-12
+make -j$(nproc)
+```
+
+System tinyxml2 is installed (`libtinyxml2-dev`). If it is missing, use `-DENABLE_FETCH_TINYXML2=ON` (as CI does).
+
+### Compiler gotchas
+- Ubuntu’s `c++` alternative may point at clang; CUDA builds should use **GCC**. Prefer `g++-12` as the CUDA host compiler with the apt `nvidia-cuda-toolkit` (12.0) package — newer GCC hosts often fail with older nvcc.
+- Shell profile in this VM sets `CC=gcc-12`, `CXX=g++-12`, `CUDAHOSTCXX=g++-12`.
+
+### Lint / test
+- No ESLint/clang-tidy target is wired in CMake. Treat successful `cmake` + `make` as the compile check.
+- `tests/test_demux.cpp` is a stub and is **not** a CMake target. Compile manually if needed:
+  `g++-12 -std=c++17 -I include tests/test_demux.cpp -o build/test_demux`
+- CI’s “basic test” is `build/cuda-demux --help` / `--version`.
+
+### Run / GPU constraint
+- This Cloud Agent VM has **no NVIDIA GPU**. `demux()` and BCL CUDA decode require a CUDA device; without one the process exits early with “No CUDA-capable GPU found”.
+- For real demux runs, use a remote GPU host over SSH (or a small HTTP API on that host). Expected secrets when configured:
+  - `GPU_SSH_HOST` (e.g. `98.210.223.214`)
+  - `GPU_SSH_USER`
+  - `GPU_SSH_PASSWORD` (or prefer key-based auth via `GPU_SSH_PRIVATE_KEY`)
+- Do **not** commit passwords or private keys into the repo.
+
+### Smoke commands (no GPU)
+```bash
+./build/cuda-demux --version
+./build/cuda-demux   # prints usage; exit 1 is expected
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `AGENTS.md` with Cursor Cloud–specific guidance for developing `cuda-demux` in GPU-less cloud agent VMs.

## What’s included
- Preferred CMake configure using `gcc-12` / `g++-12` (needed with apt CUDA 12.0)
- How to run the stub unit test and smoke `--version` / usage
- Note that real demux requires a remote NVIDIA GPU (SSH secrets: `GPU_SSH_HOST`, `GPU_SSH_USER`, `GPU_SSH_PASSWORD` or key)

## Local verification already done in the agent VM
- Installed CUDA toolkit + build deps
- Built `build/cuda-demux` successfully
- `./build/cuda-demux --version` → `1.1.0-gpu`
- Compiled and ran `tests/test_demux.cpp` (stub passes)

Remote GPU SSH was attempted against the provided host; password authentication was rejected, so end-to-end demux is blocked until working credentials are available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46e6cca2-3d02-45b2-a1bf-5fe732d0e1e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46e6cca2-3d02-45b2-a1bf-5fe732d0e1e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

